### PR TITLE
add check.names = FALSE 

### DIFF
--- a/R/flextable.R
+++ b/R/flextable.R
@@ -36,7 +36,7 @@ flextable <- function( data, col_keys = names(data) ){
   # header
   header_data <- setNames(as.list(col_keys), col_keys)
   header_data[blanks] <- as.list( rep("", length(blanks)) )
-  header_data <- as.data.frame(header_data, stringsAsFactors = FALSE)
+  header_data <- as.data.frame(header_data, stringsAsFactors = FALSE, check.names = FALSE)
 
   header <- table_part( data = header_data, col_keys = col_keys )
 


### PR DESCRIPTION
Prevent a bug when headers are not syntactically valid variable.
example:

> x <- data.frame("[0-9]" = 1:4, "[10-15]" = 5:8, check.names = FALSE)
> x
  [0-9] [10-15]
1     1       5
2     2       6
3     3       7
4     4       8
> flextable(x)
Error in f_list(...) : object '[10-15]' not found