### PR TITLE
Created a function to reduce redundant data in a tibble

### DIFF
--- a/R/reduceData.R
+++ b/R/reduceData.R
@@ -1,0 +1,35 @@
+reduceData <- function(data, keyColumnNames) {
+  library(lubridate)
+  colnamesOfData <- colnames(data)
+  valueColumnNames <- setdiff(colnamesOfData, keyColumnNames)
+  stringWhichReplacesData <- ''
+  lapply(1:(length(keyColumnNames) - 1), function(cardinalityOfSubsetOfKeyColumnNames) {
+    subsettedKeyColumnNames <-
+      combn(x = keyColumnNames, m = cardinalityOfSubsetOfKeyColumnNames)
+    apply(subsettedKeyColumnNames, 2, function(x) {
+      keyColumnNamesToTestReducability <- setdiff(keyColumnNames, x)
+      groupVector <- c(x, valueColumnNames)
+      data <<-
+        data %>% inner_join(data %>% group_by(!!!syms(groupVector)) %>% summarise(cardinalityOfGroupVector =
+                                                                                    n()),
+                            by = groupVector) %>% inner_join(data %>% group_by(!!!syms(x)) %>% summarise(cardinalityOfKeyGroups = n()),
+                                                             by = x)
+      if (all(rowSums((data %>% select(x)) == stringWhichReplacesData) !=
+          length(x))) {
+        lapply(keyColumnNamesToTestReducability, function(keyColumnNameToTestReducability) {
+          data <<-
+            data %>% mutate(
+              !!keyColumnNameToTestReducability := ifelse(
+                data$cardinalityOfGroupVector == cardinalityOfKeyGroups,
+                stringWhichReplacesData,
+                data[[keyColumnNameToTestReducability]]
+              )
+            )
+        })
+      }
+      data <<- data %>% distinct() %>% select(colnamesOfData)
+    })
+  })
+  Filter(function(x)
+    ! all(x == stringWhichReplacesData), data)
+}

--- a/tests/testthat/test-reduceData.R
+++ b/tests/testthat/test-reduceData.R
@@ -1,0 +1,14 @@
+context("reduceData")
+
+test_that("reducing a simple tibble works",{
+  dt <- tibble(k1 = c("A","A","B","B"),k2 = c("c","e","c","e"),v1 = c(2,2,2,2))
+
+  expect_equal(dt %>% reduceData(c("k1","k2")) %>% pull(v1),c(2,2))
+})
+
+test_that("if a column is independent from another column reducing the data works",{
+  dt2 <- tibble(k1 = c("A","A","B","B"),k2 = c("c","e","c","e"),v1 = c(2,2,3,2))
+
+  expect_equal(dt2 %>% reduceData(c("k1","k2")) %>% filter(k1 == "A") %>% nrow(),1)
+  expect_equal(dt2 %>% reduceData(c("k1","k2")) %>% filter(k1 == "B") %>% nrow(),2)
+})


### PR DESCRIPTION
Suppose you have a reporting table which lists the effect of the treatment of a human disease and the humans are divided by the properties country.Born, gender, eye.color. This results in a table with column names country.Born, gender, eye.colour and effectOfTreatment. Let's say, effectOfTreatment can only take the value cured or notcured, then this can become quiet a lenghty table in your report. If you have a treatment, which cured the disease for all people in a specific country independently of the gender and eye.colour, then you maybe only want to have the reporting table to have a single row, which states that the treatment was successful.
Thus, suppose you have a tibble like this:
```
treatments
# A tibble: 8 x 4
  country gender eye.color effectOfTreatment
  <chr>   <chr>  <chr>     <chr>            
1 Norway  male   green     cured            
2 Norway  male   green     notcured         
3 Norway  female blue      cured            
4 Norway  female blue      notcured         
5 Sweden  male   green     cured            
6 Sweden  male   green     cured            
7 Sweden  female blue      cured            
8 Sweden  female blue      cured            
```
Then, the function reduceData gives you the table
```
reduceData(treatments)
# A tibble: 5 x 4
  country gender eye.color effectOfTreatment
  <chr>   <chr>  <chr>     <chr>            
1 Norway  male   green     cured            
2 Norway  male   green     notcured         
3 Norway  female blue      cured            
4 Norway  female blue      notcured         
5 Sweden  ""     ""        cured            
```