### PR TITLE
Allow unused values in set_header_labels

### DIFF
--- a/R/set_headers.R
+++ b/R/set_headers.R
@@ -33,7 +33,8 @@ set_header_labels <- function(x, ..., values = NULL){
       stop("there is no header row to be replaced")
 
   }
-
+  
+  values <- values[names(values) %in% names(x$header$dataset)]
   x$header$content[nrow_part(x, "header"), names(values)] <- as_paragraph(as_chunk(unlist(values)))
 
   x


### PR DESCRIPTION
Hi David,

If you use `set_header_labels` with headers for columns A, B and C on a flextable with only columns A and B, it will return an error. 

Though, this could be very useful when using a common header/name dictionary, shared across multiple flextables with different column selection:

```{r}
dict = c(Sepal.Length="The Sepal Length", Sepal.Width="The Sepal Width",Petal.Length="The Petal Length", 
         Petal.Width="The Petal Width", Species="The Specie")
iris %>% flextable %>% set_header_labels(values=dict) #OK
iris %>% flextable(col_keys = c("Sepal.Length", "Species")) %>% set_header_labels(values=dict) #Error
```

> Error in \`[<-\`(\`\*tmp\*\`, i, j, value = value) : indice hors limites

With, `trace(flextable::set_header_labels, edit = T)`, I added the requested line which removed this error. It might need a little more testing but it seems quite safe to me.

I hope it helped.
Dan