### PR TITLE
add: support for bookdown cross reference

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,13 @@ Imports:
     base64enc
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
-Suggests: testthat, xtable, magrittr, webshot, magick, ggplot2
+Suggests: 
+    testthat (>= 2.1.0),
+    xtable,
+    magrittr,
+    webshot,
+    magick,
+    ggplot2
 Encoding: UTF-8
 URL: https://davidgohel.github.io/flextable
 BugReports: https://github.com/davidgohel/flextable/issues

--- a/R/html_str.R
+++ b/R/html_str.R
@@ -1,16 +1,21 @@
-html_str <- function( x ){
+html_str <- function( x, ... ){
   UseMethod("html_str")
 }
 
 
-html_str.flextable <- function( x ){
+html_str.flextable <- function( x, bookdown = FALSE ){
 
   dims <- dim(x)
 
 
   out <- paste0("<table style='border-collapse:collapse;", sprintf("width:%s;", css_px(sum(dims$widths) * 72) ), "'>")
-  if(!is.null(x$caption$value)){
-    out <- paste0(out, "<caption>", htmlEscape(x$caption$value), "</caption>" )
+  cap = x$caption$value
+  if(!is.null(cap)){
+    out <- paste0(
+      out, if ( bookdown ) "<!--/html_preserve-->", "<caption>",
+      if ( bookdown && !has_label(cap)) ref_label(), htmlEscape(cap),
+      if ( bookdown ) "<!--html_preserve-->", "</caption>"
+    )
   }
 
   if( nrow_part(x, "header") > 0 ){

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,3 +91,13 @@ absolute_path <- function(x){
   epath
 }
 
+#' @inportFrom knitr opts_current
+ref_label <- function() {
+  label <- opts_current$get('label')
+  if (is.null(label)) return('')
+  paste0("(\\#tab:", label, ")")
+}
+
+has_label <- function(x) {
+  grepl("^\\(\\\\#tab:[-[:alnum:]]+\\)", x)
+}

--- a/man/docx_value.Rd
+++ b/man/docx_value.Rd
@@ -9,7 +9,8 @@ docx_value(
   print = TRUE,
   ft.align = opts_current$get("ft.align"),
   ft.split = opts_current$get("ft.split"),
-  tab.cap.style = opts_current$get("tab.cap.style")
+  tab.cap.style = opts_current$get("tab.cap.style"),
+  bookdown = FALSE
 )
 }
 \arguments{
@@ -24,6 +25,8 @@ activated when TRUE.}
 
 \item{tab.cap.style}{specifies a Word style for table caption,
 default value is "Table Caption".}
+
+\item{bookdown}{\code{TRUE} or \code{FALSE} (defailt) to support cross referencing with bookdown.}
 }
 \description{
 get openxml raw code for Word

--- a/man/htmltools_value.Rd
+++ b/man/htmltools_value.Rd
@@ -4,7 +4,12 @@
 \alias{htmltools_value}
 \title{flextable as a div object}
 \usage{
-htmltools_value(x, ft.align = opts_current$get("ft.align"), class = "tabwid")
+htmltools_value(
+  x,
+  ft.align = opts_current$get("ft.align"),
+  class = "tabwid",
+  bookdown = FALSE
+)
 }
 \arguments{
 \item{x}{a flextable object}
@@ -13,6 +18,8 @@ htmltools_value(x, ft.align = opts_current$get("ft.align"), class = "tabwid")
 
 \item{class}{css classes (default to "tabwid"), if ft.align is set to 'left' or 'right',
 class 'tabwid_left' or 'tabwid_right' will be added to class.}
+
+\item{bookdown}{\code{TRUE} or \code{FALSE} (defailt) to support cross referencing with bookdown.}
 }
 \description{
 get a \code{\link[htmltools]{div}} from a flextable object.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,11 @@
+test_that("Adds label for cross referencing with bookdown", {
+  expect_identical(ref_label(), "")
+  knitr::opts_current$set(label = 'foo')
+  expect_identical(ref_label(), "(\\#tab:foo)")
+})
+
+test_that("Check if a reference label is explicitly specified", {
+  expect_false(has_label('foo'))
+  expect_true(has_label('(\\#tab:foo)'))
+  expect_true(has_label('(\\#tab:fo-o)'))
+})


### PR DESCRIPTION
See https://github.com/davidgohel/flextable/issues/169#issuecomment-600971506 for the basic idea 

closes atusy/ftExtra#5 #193 #169
solves rstudio/bookdown#746 rstudio/bookdown#659

# Reprex

````
---
output:
    bookdown::html_document2: null
    bookdown::word_document2: null
---

```{r setup}
library(magrittr)
library(flextable)
```

Referencing table \@ref(tab:iris).

# Basically, cross reference is supported via chunk label

Chunk label can be null as knitr will automatically defines it.

\@ref(tab:ft)

```{r ft}
iris %>% head %>% flextable %>% set_caption('A caption with table number.')
```

# In case users want to label the table explicitly, they can do so like

\@ref(tab:iris)

```{r}
iris %>% head %>% flextable %>% set_caption('(\\#tab:iris) A caption with table number.')
```
````