### PR TITLE
Add tfoot tag, Close #256

### DIFF
--- a/R/html_str.R
+++ b/R/html_str.R
@@ -133,7 +133,13 @@ html_gen <- function(x){
   header_start <- head(which(parts %in% "header"), n = 1)
   header_end <- tail(which(parts %in% "header"), n = 1)
   body_start <- head(which(parts %in% "body"), n = 1)
-  body_end <- nrow(z)
+  body_end <- tail(which(parts %in% "body"), n = 1)
+  if ("footer" %in% parts) {
+    footer_start <- head(which(parts %in% "footer"), n = 1)
+    footer_end <- nrow(z)
+  } else {
+    body_end <- nrow(z)
+  }
 
   z$tpart_start <- ""
   z$tpart_end <- ""
@@ -141,6 +147,8 @@ html_gen <- function(x){
   z$tpart_end[header_end] <- "</thead>"
   z$tpart_start[body_start] <- "<tbody>"
   z$tpart_end[body_end] <- "</tbody>"
+  if (exists("footer_start")) z$tpart_start[footer_start] <- "<tfoot>"
+  if (exists("footer_end")) z$tpart_end[footer_end] <- "</tfoot>"
   setcolorder(z, neworder = c("tpart_start", "tr_tag"))
 
   z[, c("part", "ft_row_id") := NULL]


### PR DESCRIPTION
Hi David,

This PR closes #256.

When testing the change the footer had a 1px border around it. This happens also with an unmodified version of the master branch. When I roll back to the state of the last CRAN version (https://github.com/davidgohel/flextable/tree/8e8c7eb3f4ae153aef08c7d800f72a07f1f08bf4) the border is gone, even with this change. This is why I assume it has nothing to do with the added footer tag. Maybe you know where this is coming from, or I can debug it further.

If I can do anything else I am happy to help.

Greetings, 
Alex

Code:
```
flextable(iris[1,]) %>%
  add_footer_lines("test")
```

Version 8th September:
![image](https://user-images.githubusercontent.com/5631424/98941188-7b08fb00-24ec-11eb-89cd-87a68c36eb0a.png)

Version Master
![image](https://user-images.githubusercontent.com/5631424/98941213-8825ea00-24ec-11eb-9355-a2f1b090f4e5.png)
