### PR TITLE
Fix #268: Use generic format_fun instead of format_fun.default

### DIFF
--- a/R/tabpart_mains.R
+++ b/R/tabpart_mains.R
@@ -27,7 +27,7 @@ complex_tabpart <- function( data, col_keys = names(data),
     newcontent <- lapply(
       data[col_keys],
       function(x) {
-        as_paragraph(as_chunk(x, formatter = format_fun.default) )
+        as_paragraph(as_chunk(x) )
       })
     content$content[,col_keys] <- Reduce(append, newcontent)
   }


### PR DESCRIPTION
Hi David,

there are 2 bugs, which created this problem. On Windows `format()` can't handle utf-8 symbols. (Probably since the native Encoding is still a special version of ASCII)

```
format("≥")
[1] "="
format("↑")
[1] "<U+2191>"
```

On Linux (and probably macOS) this works.

The second bug was that `format_fun()` always used the default generic. This was harder to track down. The default behaviour of `as_chunk()` was overridden, which resulted in always calling `format_fun.default()` (see commit). (But calling `as_chunk()` directly still worked.)

Greetings,
Alex