### PR TITLE
Feature: higher precision spacing

### DIFF
--- a/R/tabpart_format.R
+++ b/R/tabpart_format.R
@@ -1,5 +1,5 @@
 # utils -----
-css_pt <- function(x, digits = 0){
+css_pt <- function(x, digits = 1){
   x <- ifelse( is.na(x), "inherit",
           ifelse( x < 0.001, "0",
                   paste0(format_double(x, digits = digits),"pt")))


### PR DESCRIPTION
Hi David,

since 0.6.0 all values for font size and spacing are in "pt" instead of "px". Since the conversion factor between the two is non-integer, a decimal place is needed to specify the same values as before this change. This also allows for higher precision when specifying padding and margins.

If you like I could also add a function `px_to_pt()` to the package to assist with the conversion of old code. Or there could be a global option to use "px" instead of "pt" to allow for full backward compatibility.

Greetings,
Alex


