### PR TITLE
add a peek_flextable() function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -126,3 +126,36 @@ format_double <- function(x, digits = 2){
 }
 
 
+
+#' Peek at a flextable
+#' 
+#' Create a dummy MS Word document containing only the flextable and open it.
+#' This is most useful for copy-pasting.
+#'
+#' @param x a flextable
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' ft = flextable(iris) 
+#' peek_flextable(ft)
+#' }
+peek_flextable = function(x){
+  temp=tempfile(fileext=".docx")
+  tryCatch({
+    if(file.exists(temp)) {
+      file.remove(temp )
+    }
+    doc <- body_add_flextable(read_docx(), x)
+    print(doc, temp)
+    shell.exec(temp)
+  }, error=function(e) {
+    message("Error: File is probably already open")
+    message(e)
+  }, warning=function(w) {
+    message("Warning: File is probably already open")
+    message(w)
+  }, finally={}
+  )
+}


### PR DESCRIPTION
This function allows one to instantly visualize a flextable in a Word document and proved very handy over time so I thought of proposing it.

It is especially useful as RStudio's viewer pane does not allow copy-pasting flextables: it pastes plain text or adds awful borders (if shown in a new window before copying).

I tested it on Windows 10 on different configurations, but it might need a test on Apple and Linux computers if possible as `shell.exec` might not behave as well on those.