### PR TITLE
Fix missing top or right border in LaTeX output

### DIFF
--- a/R/latex_str.R
+++ b/R/latex_str.R
@@ -254,7 +254,7 @@ augment_borders <- function(properties_df) {
   properties_df[, c("vborder_left", "vborder_right", "hhlines_bottom", "hhlines_top") :=
     list(
       latex_vborder(w = .SD$border.width.left, cols = .SD$border.color.left),
-      fcase(.SD$col_id %in% tail(levels(.SD$col_id), 1),
+      fcase(as.numeric(.SD$col_id) + .SD$rowspan == nlevels(.SD$col_id) + 1,
         latex_vborder(w = .SD$border.width.right, cols = .SD$border.color.right),
         default = ""
       ),

--- a/R/latex_str.R
+++ b/R/latex_str.R
@@ -233,10 +233,9 @@ augment_part_separators <- function(z) {
 }
 
 augment_top_borders <- function(properties_df) {
-  first_level <- head(levels(properties_df$part), 1)
-
   hhline_top_data <- properties_df[
-    properties_df$ft_row_id %in% 1 & properties_df$part %in% first_level,
+    properties_df$ft_row_id %in% 1 &
+    as.numeric(properties_df$part) == min(as.numeric(properties_df$part)),
     list(
       hhline_top = paste0("\\hhline{", paste0(.SD$hhlines_top, collapse = ""), "}")
     ),
@@ -260,7 +259,7 @@ augment_borders <- function(properties_df) {
       ),
       latex_hhline(w = .SD$border.width.bottom, cols = .SD$border.color.bottom),
       fcase(.SD$ft_row_id %in% 1 &
-        .SD$part %in% head(levels(.SD$part), 1),
+        as.numeric(.SD$part) == min(as.numeric(.SD$part)),
       latex_hhline(w = .SD$border.width.top, cols = .SD$border.color.top),
       default = ""
       )


### PR DESCRIPTION
Hi David, thank you for creating this great package.

I recently use flextable in `bookdown` to format and display some complex tables.
And in some cases the LaTeX output is missing some table borders,
either when a merged cell occurs on the rightmost side of a table, or when the header is deleted.

I think issue #329 and #176 also report similar problems.

After digging into the source code, I found that there may be something wrong with the `augment_(top_)borders` function.

For example, when `augment_borders` function computes if a right border should be emitted,
it checks whether the `col_id` matches the `col_id` of the rightmost column,
this is ok for ordinary cells, but not the case for merged ones.

Instead, we can take `rowspan` into consideration and check if `numeric_col_id + rowspan == no._of_columns + 1`.

Also, when this function emits top border (`hhline`),
it checks if `ft_row_id` is 1 and if the `part` is the first of all three table parts (which is always `header`).
So when the table header is deleted, no top border will be produced.

And we can change its behavior to check if `part` is the first of **existing** table parts (it's `body` in case `header` is missing).

As to the coding style, I'm new to R lang, and I think there may be better ways to express these checks.
Please feel free to correct the code if you have better ideas.  :-)
