### PR TITLE
Add a check on value in body_add_flextable()

### DIFF
--- a/R/body_add_flextable.R
+++ b/R/body_add_flextable.R
@@ -29,6 +29,7 @@ body_add_flextable <- function( x, value, align = "center", pos = "after", split
                                 topcaption = TRUE) {
 
   stopifnot(inherits(x, "rdocx"))
+  stopifnot(inherits(value, "flextable"))
 
   if(topcaption && !is.null(value$caption$value)){
     bc <- block_caption(label = value$caption$value,


### PR DESCRIPTION
Hi David,

Just a very minor PR here.

I find myself wanting to insert dataframes directly into officer documents more often than I'd like to admit, and the error message that I get then is not very clear:

``` r
library(tidyverse)
officer::read_docx() %>% flextable::body_add_flextable(iris)
#> Error: $ operator is invalid for atomic vectors
```

With that `stopifnot()` addition, it will be clearer that the problem is that `value` is not a flextable.

In fact, I think that `body_add_flextable()` might even accept dataframes by design.

For instance you could consider something like this:

``` r
body_add_flextable <- function( x, value, align = "center", pos = "after", split = FALSE,
                                topcaption = TRUE, ...) {
  if(is.data.frame(value)) value <- flextable(value, ...) # pass on the ellipsis

  stopifnot(inherits(x, "rdocx"))
  stopifnot(inherits(value, "flextable"))
  # rest of the function
}
```

