### PR TITLE
support tidyselect helpers if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
     xtable,
     webshot,
     magick,
-    ggplot2, scales, 
+    ggplot2, scales, tidyselect,
     broom, mgcv,
     bookdown, equatags,
     commonmark,pdftools

--- a/R/flextable.R
+++ b/R/flextable.R
@@ -44,6 +44,9 @@ flextable <- function( data, col_keys = names(data), cwidth = .75, cheight = .25
 
 
   stopifnot(is.data.frame(data), ncol(data) > 0 )
+  if( requireNamespace("tidyselect", quietly = TRUE) && requireNamespace("rlang", quietly = TRUE) ){
+    col_keys <- names(tidyselect::eval_select(rlang::enexpr(col_keys), data))
+  }
   if( any( duplicated(col_keys) ) ){
     stop("duplicated col_keys")
   }

--- a/R/flextable.R
+++ b/R/flextable.R
@@ -45,7 +45,10 @@ flextable <- function( data, col_keys = names(data), cwidth = .75, cheight = .25
 
   stopifnot(is.data.frame(data), ncol(data) > 0 )
   if( requireNamespace("tidyselect", quietly = TRUE) && requireNamespace("rlang", quietly = TRUE) ){
-    col_keys <- names(tidyselect::eval_select(rlang::enexpr(col_keys), data))
+    try_col_keys <- try(col_keys, silent=TRUE)
+    if( inherits(try_col_keys, "try-error") ){
+      col_keys <- names(tidyselect::eval_select(rlang::enquo(col_keys), data, strict = FALSE))
+    }
   }
   if( any( duplicated(col_keys) ) ){
     stop("duplicated col_keys")


### PR DESCRIPTION
Salut David,

I'd love to be able to use `tidyselect` with flextable.

With this PR, you should be able to write `flextable(iris, col_keys=-Species)` or  `flextable(iris, col_keys=starts_with("Sepal")))`.

As you may not want to import these packages in {flextable}, I wrapped them in a `requireNamespace()` so this triggers only if the package is available.

However, I'm seeing that you are throwing an error on `duplicated(col_keys)`. Note that this error will be silenced after this PR, as `tidyselect::eval_select()` automatically removes duplicates. For instance, try `flextable2(iris, col_keys=c(Species, Species))`. 

Working with quosures can be a bit complicated so I'm not sure that you can check for duplicates (and throw a warning maybe?) and use `tidyselect`, but maybe someone else knows.

IMHO, I think that the added feature is worth the missing check though.

A bientôt
Dan


EDIT: oops, it seems to not work very well with dummy columns as separators. I'll try to work around this.

EDIT2: it seems to work now, although this is not the most elegant code ever. I'm using `try()` to see if `col_keys` can be evaluated without error, which will be the case if it is not a plain character vector. In this case, I pass it to `tidyselect::eval_select()` for NSE. 
In the end, you can use tidyselect and separators, just not both at the same time unfortunately. If you are better than me with working with quosure, I'd love to see you allowing to write `flextable2(iris, col_keys=c(starts_with("Sepal"), "sep1", starts_with("Petal")))`.