### PR TITLE
Add suggestion for ft.arraystretch

### DIFF
--- a/R/flextable_sizes.R
+++ b/R/flextable_sizes.R
@@ -134,6 +134,7 @@ height <- function(x, i = NULL, height, part = "body", unit = "in"){
 #' @description control rules of each height for a part
 #' of the flextable, this is only for Word and PowerPoint outputs, it
 #' will not have any effect when output is HTML or PDF.
+#' For PDF see the ft.arraystretch chunk option.
 #' @param x flextable object
 #' @param i rows selection
 #' @param rule specify the meaning of the height. Possible values


### PR DESCRIPTION
It is quite hard to find that ft.arraystretch is how you would do this for PDFs so I thought it may be worth adding here.