### PR TITLE
rmarkdown expects list of dependencies to be unnamed

### DIFF
--- a/R/latex_str.R
+++ b/R/latex_str.R
@@ -16,7 +16,7 @@
 #' @importFrom knitr knit_meta_add
 add_latex_dep <- function(float = FALSE, wrapfig = FALSE){
 
-  knit_meta_add(list_latex_dep(float = float, wrapfig = wrapfig))
+  knit_meta_add(unname(list_latex_dep(float = float, wrapfig = wrapfig)))
 
   invisible(NULL)
 }

--- a/R/printers.R
+++ b/R/printers.R
@@ -650,7 +650,7 @@ knit_print.flextable <- function(x, ...) {
     str <- knit_to_latex(x, bookdown = is_bookdown, quarto = is_quarto)
     str <- raw_latex(
       x = str,
-      meta = list_latex_dep(float = TRUE, wrapfig = TRUE)
+      meta = unname(list_latex_dep(float = TRUE, wrapfig = TRUE))
     )
   } else if (grepl("docx", opts_knit$get("rmarkdown.pandoc.to"))) { # docx
     if (pandoc_version() < numeric_version("2")) {


### PR DESCRIPTION
This property is used in HTML or LaTeX deps resolution to know when to be recursive. 

This is caused by changed in cc805164f9c3e965e9c7e65983cba42966498746 which introduced the name

Quite specific case encountered with Quarto processing at https://github.com/quarto-dev/quarto-cli/issues/5093. This PR solves https://github.com/quarto-dev/quarto-cli/issues/5093#issuecomment-1496692965 issue

You could also remove the name completely inside `list_latex_dep()` 

Regarding the convention, this is here in **rmarkdown** 
https://github.com/rstudio/rmarkdown/blame/main/R/html_dependencies.R#L382-L400
````r
has_dependencies <- function(knit_meta, class) {
  if (inherits(knit_meta, class))
    return(TRUE)
  if (is.list(knit_meta)) {
    for (dep in knit_meta) {
      if (is.null(names(dep))) { # <<- if unnamed we considered we should recurse
        if (has_dependencies(dep, class))
          return(TRUE)
      } else { # <<- if named then we check if it inherits the class, as a html / latex dependency would
        if (inherits(dep, class))
          return(TRUE)
      }
    }
  }
  FALSE
}
````

