### PR TITLE
The next version of bookdown will generate bookmarks for tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     xtable, tables,
     broom, broom.mixed, 
     mgcv, cluster, lme4, nlme,
-    bookdown, pdftools, officedown,
+    bookdown (>= 0.34), pdftools, officedown,
     pkgdown (>= 2.0.0), webshot2
 Encoding: UTF-8
 URL: https://ardata-fr.github.io/flextable-book/, https://davidgohel.github.io/flextable/

--- a/tests/testthat/test-captions-rmd.R
+++ b/tests/testthat/test-captions-rmd.R
@@ -147,7 +147,7 @@ testthat::test_that("with word_document2", {
   )
 
   bookmarks <- xml_find_all(doc, "//w:tbl/preceding-sibling::w:p[1]/w:bookmarkStart")
-  expect_length(bookmarks, 0)
+  expect_length(bookmarks, 3)
 })
 
 


### PR DESCRIPTION
so the length of bookmarks should be 3 here.

cf https://github.com/rstudio/bookdown/pull/1426

Thanks!