### PR TITLE
Add colwidth=all to add_footer_row()

### DIFF
--- a/R/augment_rows.R
+++ b/R/augment_rows.R
@@ -704,7 +704,7 @@ add_header_row <- function(x, top = TRUE, values = character(0), colwidths = int
 #' @export
 #' @title Add footer labels
 #'
-#' @description Add a row of new columns labels in footer part.
+#' @description Add a row of new column labels in the footer part.
 #' Labels can be spanned along multiple columns, as merged cells.
 #'
 #' Labels are associated with a number of columns
@@ -745,6 +745,7 @@ add_header_row <- function(x, top = TRUE, values = character(0), colwidths = int
 #'   colwidths = c(3, 8), top = TRUE
 #' )
 #' ft_1
+#' add_footer_row(ft_1, values="My tailor and baker are rich", top=FALSE, colwidths="all")
 #'
 #' ft_2 <- flextable(head(airquality))
 #' ft_2 <- add_footer_row(ft_2,
@@ -758,6 +759,7 @@ add_footer_row <- function(x, top = TRUE, values = character(0), colwidths = int
     stop(sprintf("Function `%s` supports only flextable objects.", "add_footer_row()"))
   }
 
+  if (colwidths == "all") colwidths <- length(x$col_keys)
   if (sum(colwidths) != length(x$col_keys)) {
     stop(sprintf(
       "`colwidths` argument specify room for %.0f columns but %.0f are expected.",


### PR DESCRIPTION
Hi David,

Most often, when I want to add a footer row, it is mostly to add an addendum to my table so I want a single value that takes all the width.
Also, it can be tedious to count the number of columns in big tables, so filling `colwidth` is a bit annoying for a thing that could be automated.

I hereby propose to add a `colwidth="all"` shortcut syntax to fill this need:

```r
ft_1 <- flextable(head(mtcars))
add_footer_row(ft_1, values="I am rich too", top=FALSE, colwidths="all")
```

On second thought, maybe this should be the default behavior instead of `numeric(0)`, so that when `value` is of length 1 `colwidths` is set to the whole table width. This way you don't change the interface, only the default.
Let me know what you think and I'll change my PR if needed (and considered).