### PR TITLE
Fix to `align()`'s default `align` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flextable
 Type: Package
 Title: Functions for Tabular Reporting
-Version: 0.9.6.007
+Version: 0.9.6.008
 Authors@R: c(
     person("David", "Gohel", role = c("aut", "cre"),
     email = "david.gohel@ardata.fr"),
@@ -68,7 +68,7 @@ Suggests:
     scales,
     svglite,
     tables (>= 0.9.17),
-    testthat (>= 2.1.0),
+    testthat (>= 3.0.0),
     webshot2,
     withr,
     xtable
@@ -76,3 +76,4 @@ Encoding: UTF-8
 URL: https://ardata-fr.github.io/flextable-book/, https://davidgohel.github.io/flextable/
 BugReports: https://github.com/davidgohel/flextable/issues
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,35 +1,44 @@
-Package: flextable
 Type: Package
+Package: flextable
 Title: Functions for Tabular Reporting
 Version: 0.9.6.008
 Authors@R: c(
-    person("David", "Gohel", role = c("aut", "cre"),
-    email = "david.gohel@ardata.fr"),
-    person(given = "ArData", role = "cph"),
+    person("David", "Gohel", , "david.gohel@ardata.fr", role = c("aut", "cre")),
+    person("ArData", role = "cph"),
     person("Clementine", "Jager", role = "ctb"),
-    person("Panagiotis", "Skintzos", role = "aut", email = "panagiotis.skintzos@ardata.fr"),
+    person("Panagiotis", "Skintzos", , "panagiotis.skintzos@ardata.fr", role = "aut"),
     person("Quentin", "Fazilleau", role = "ctb"),
-    person("Maxim", "Nazarov", role = "ctb", comment = "rmarkdown for docx output"),
+    person("Maxim", "Nazarov", role = "ctb",
+           comment = "rmarkdown for docx output"),
     person("Titouan", "Robert", role = "ctb"),
-    person("Michael", "Barrowman", role = "ctb", comment = "inline footnotes"),
-    person("Atsushi", "Yasumoto", role = "ctb", comment = "support for bookdown cross reference"),
-    person("Paul", "Julian", role = "ctb", comment = "support for gam objects"),
-    person("Sean", "Browning", role = "ctb", comment = "work on footnote positioning system"),
-    person("Rémi", "Thériault", role = "ctb", comment = c(ORCID = "0000-0003-4315-6788", ctb = "theme_apa")),
-    person("Samuel", "Jobert", role = "ctb", comment = "work on pagination")
-    )
+    person("Michael", "Barrowman", role = "ctb",
+           comment = "inline footnotes"),
+    person("Atsushi", "Yasumoto", role = "ctb",
+           comment = "support for bookdown cross reference"),
+    person("Paul", "Julian", role = "ctb",
+           comment = "support for gam objects"),
+    person("Sean", "Browning", role = "ctb",
+           comment = "work on footnote positioning system"),
+    person("Rémi", "Thériault", role = "ctb",
+           comment = c(ORCID = "0000-0003-4315-6788", ctb = "theme_apa")),
+    person("Samuel", "Jobert", role = "ctb",
+           comment = "work on pagination")
+  )
 Description: Use a grammar for creating and customizing pretty tables.
- The following formats are supported: 'HTML', 'PDF', 'RTF', 
- 'Microsoft Word', 'Microsoft PowerPoint' and R 'Grid Graphics'. 
- 'R Markdown', 'Quarto' and the package 'officer' can be used to produce 
- the result files. The syntax is the same for the user regardless of 
- the type of output to be produced. A set of functions allows the 
- creation, definition of cell arrangement, addition of headers or 
- footers, formatting and definition of cell content with text and 
- or images. The package also offers a set of high-level functions 
- that allow tabular reporting of statistical models and the 
- creation of complex cross tabulations.
+    The following formats are supported: 'HTML', 'PDF', 'RTF', 'Microsoft
+    Word', 'Microsoft PowerPoint' and R 'Grid Graphics'.  'R Markdown',
+    'Quarto' and the package 'officer' can be used to produce the result
+    files. The syntax is the same for the user regardless of the type of
+    output to be produced. A set of functions allows the creation,
+    definition of cell arrangement, addition of headers or footers,
+    formatting and definition of cell content with text and or images. The
+    package also offers a set of high-level functions that allow tabular
+    reporting of statistical models and the creation of complex cross
+    tabulations.
 License: GPL-3
+URL: https://ardata-fr.github.io/flextable-book/,
+    https://davidgohel.github.io/flextable/
+BugReports: https://github.com/davidgohel/flextable/issues
 Imports:
     data.table (>= 1.13.0),
     gdtools (>= 0.3.6),
@@ -46,14 +55,12 @@ Imports:
     utils,
     uuid (>= 0.1-4),
     xml2
-RoxygenNote: 7.3.1
-Roxygen: list(markdown = TRUE)
 Suggests:
     bookdown (>= 0.34),
     broom,
     broom.mixed,
-    cluster,
     chromote,
+    cluster,
     commonmark,
     doconv (>= 0.3.0),
     equatags,
@@ -72,8 +79,9 @@ Suggests:
     webshot2,
     withr,
     xtable
-Encoding: UTF-8
-URL: https://ardata-fr.github.io/flextable-book/, https://davidgohel.github.io/flextable/
-BugReports: https://github.com/davidgohel/flextable/issues
-VignetteBuilder: knitr
+VignetteBuilder: 
+    knitr
 Config/testthat/edition: 3
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# flextable 0.9.6.007 (Development version)
+
+## Changes
+
+- {testthat} version 3 now used for testing
+    - Removes `context()` as this is encapsulated by the test file name.
+    - Swaps `expect_equivalent()` with `expect_equal(ignore_attr = TRUE)`
+    - Swaps `expect_is()` for `expect_s3_class()`.
+
 # flextable 0.9.6
 
 ## Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# flextable 0.9.6.008 (Development version)
+# flextable 0.9.6.009 (Development version)
 
 ## Changes
 
@@ -22,6 +22,7 @@
     - Removes `context()` as this is encapsulated by the test file name.
     - Swaps `expect_equivalent()` with `expect_equal(ignore_attr = TRUE)`
     - Swaps `expect_is()` for `expect_s3_class()`.
+- DESCRIPTION file passed through `usethis::use_tidy_description()`.
 
 # flextable 0.9.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,23 @@
-# flextable 0.9.6.007 (Development version)
+# flextable 0.9.6.008 (Development version)
 
 ## Changes
 
+- BREAKING CHANGE: in `align()`, the default argument value for `align`
+  is now `"left"`, rather than `c("left", "center", "right", "justify")`.
+  This returns the default value to how it was in older versions of {flextable}.
+    - in `align()`, use of the old default `align` argument could cause an error
+      if the number of columns being adjusted was not a multiple of 4.
+    - The documentation specified that `align` had to be a single value, when
+      it could actually accept multiple values. This is why a default value of
+      `c("left", "center", "right", "justify")`, was problematic.
+      This documentation has now been updated and
+      new examples included in the documentation.
+    - The default `align` argument will now apply left alignment to all columns in
+      the body.
+    - If the user specifies an alignment that is invalid, a warning will be displayed
+      and the invalid value will be ignored (dropped).
+    - The `path` argument now has a signature of `part = c("body", "header", "footer", "all")`,
+      but because only a single value can be selected, it will pick `"body"` by default, as before.
 - {testthat} version 3 now used for testing
     - Removes `context()` as this is encapsulated by the test file name.
     - Swaps `expect_equivalent()` with `expect_equal(ignore_attr = TRUE)`

--- a/man/align.Rd
+++ b/man/align.Rd
@@ -10,8 +10,8 @@ align(
   x,
   i = NULL,
   j = NULL,
-  align = c("left", "center", "right", "justify"),
-  part = "body"
+  align = "left",
+  part = c("body", "header", "footer", "all")
 )
 
 align_text_col(x, align = "left", header = TRUE, footer = TRUE)
@@ -25,10 +25,15 @@ align_nottext_col(x, align = "right", header = TRUE, footer = TRUE)
 
 \item{j}{columns selection}
 
-\item{align}{text alignment - a single character value, expected value
-is one of 'left', 'right', 'center', 'justify'.}
+\item{align}{text alignment - a single character value, or a vector of
+character values equal in length to the number of columns selected by \code{j}.
+Expected values must be from the set of ('left', 'right', 'center', or 'justify').
+You can also use shortened versions of these options: ("l", "r", "c", "j").
 
-\item{part}{partname of the table (one of 'all', 'body', 'header', 'footer')}
+If the number of columns is a multiple of the length of the \code{align} parameter,
+then the values in \code{align} will be recycled across the remaining columns.}
+
+\item{part}{partname of the table (one of 'body', 'header', 'footer', 'all')}
 
 \item{header}{should the header be aligned with the body}
 
@@ -38,10 +43,24 @@ is one of 'left', 'right', 'center', 'justify'.}
 change text alignment of selected rows and columns of a flextable.
 }
 \examples{
-ft <- flextable(head(mtcars)[, 3:6])
-ft <- align(ft, align = "right", part = "all")
-ft <- theme_tron_legacy(ft)
-ft
+# Table of 6 columns
+ft_car <- flextable(head(mtcars)[, 2:7])
+
+# All 6 columns right aligned
+align(ft_car, align = "right", part = "all")
+
+# Manually specify alignment of each column
+align(ft_car, align = c("left", "right", "left", "center", "center", "right"), part = "all")
+
+# Center-align column 2 and left-align column 5
+align(ft_car, j = c(2, 5), align = c("center", "left"), part = "all")
+
+# Alternate left and center alignment across columns 1-4 for header only
+align(ft_car, j = 1:4, align = c("left", "center"), part = "header")
+
+# Using shorthand codes for alignment arguments.
+align(ft_car, align = c("l", "r", "l", "c", "j", "r"), part = "all")
+
 ftab <- flextable(mtcars)
 ftab <- align_text_col(ftab, align = "left")
 ftab <- align_nottext_col(ftab, align = "right")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
 library(testthat)
+library(flextable)
 
 test_check("flextable")

--- a/tests/testthat/_snaps/styles.md
+++ b/tests/testthat/_snaps/styles.md
@@ -1,0 +1,109 @@
+# align() accepts default align argument when columns is not a multiple of 4
+
+    structure(c("left", "left", "left", "left", "left", "left"), dim = c(1L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("left", "left", "left", "left", "left", "left", "left", 
+    "left", "left", "left", "left", "left"), dim = c(2L, 6L), dimnames = list(
+        NULL, c("mpg", "cyl", "disp", "hp", "drat", "wt")))
+
+# align() accepts combinations of align arguments.
+
+    structure(c("right", "right", "right", "right", "right", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "right", "right", 
+    "right", "right", "right", "right", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("left", "right", "left", "center", "center", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("left", "left", "right", "right", "left", "left", 
+    "center", "center", "center", "center", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "right", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "center", "center", 
+    "right", "right", "left", "left", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "right", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "center", "center", 
+    "right", "right", "left", "left", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("right", "right", "center", "right", "center", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "center", "center", 
+    "right", "right", "center", "center", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("left", "center", "left", "center", "right", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("right", "right", "right", "right", "right", "right", 
+    "right", "right", "right", "right", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+---
+
+    structure(c("left", "right", "left", "center", "justify", "right"
+    ), dim = c(1L, 6L), dimnames = list(NULL, c("mpg", "cyl", "disp", 
+    "hp", "drat", "wt")))
+
+---
+
+    structure(c("left", "left", "right", "right", "left", "left", 
+    "center", "center", "justify", "justify", "right", "right"), dim = c(2L, 
+    6L), dimnames = list(NULL, c("mpg", "cyl", "disp", "hp", "drat", 
+    "wt")))
+
+# align() will error if invalid align and part arguments are supplied
+
+    structure(c("left", "left", "left", "left", "left", "left", "left", 
+    "left", "left", "left", "left", "left"), dim = c(2L, 6L), dimnames = list(
+        NULL, c("mpg", "cyl", "disp", "hp", "drat", "wt")))
+

--- a/tests/testthat/test-as_flextable.R
+++ b/tests/testthat/test-as_flextable.R
@@ -1,5 +1,3 @@
-context("check as_flextable")
-
 test_that("data.frame", {
   dummy_df <- data.frame(
     A = rep(letters[1:3], each = 2),

--- a/tests/testthat/test-borders.R
+++ b/tests/testthat/test-borders.R
@@ -1,5 +1,3 @@
-context("check borders rendering")
-
 init_flextable_defaults()
 snap_folder_test_file <- "borders"
 defer_cleaning_snapshot_directory(snap_folder_test_file)

--- a/tests/testthat/test-captions-rmd.R
+++ b/tests/testthat/test-captions-rmd.R
@@ -1,5 +1,3 @@
-context("check captions")
-
 init_flextable_defaults()
 
 rmd_file_0 <- "rmd/captions.Rmd"

--- a/tests/testthat/test-cell_content.R
+++ b/tests/testthat/test-cell_content.R
@@ -1,5 +1,3 @@
-context("check cell content")
-
 test_that("void works as expected", {
   expect_error(void(12, part = "all"))
 
@@ -42,7 +40,7 @@ test_that("flextable_defaults values for cell content", {
       "1 116 933", "dark", "01/01/2011 09:09:09", "Adrien Dupuy", "29 02 2028",
       "2", "53,58175", "167,7560", "1 009 038", "dark", "01/01/2011 09:09:09"
     )
-  expect_equivalent(object = information_data_chunk(ft)$txt, expected)
+  expect_equal(object = information_data_chunk(ft)$txt, expected, ignore_attr = TRUE)
 
   init_flextable_defaults()
 })
@@ -79,7 +77,7 @@ test_that("colformat_* functions", {
       "-26/02/2011-", "-c-", "-b-", "-12,566-", "-4-", "-NON-", "-01/01/2011 090905-",
       "-27/02/2011-"
     )
-  expect_equivalent(object = information_data_chunk(ft)$txt, expected)
+  expect_equal(object = information_data_chunk(ft)$txt, expected, ignore_attr = TRUE)
 
   ft <- colformat_num(x = ft, big.mark = "", decimal.mark = ".", prefix = "+", suffix = "+")
   expected <-
@@ -91,7 +89,7 @@ test_that("colformat_* functions", {
       "-26/02/2011-", "-c-", "-b-", "+12.566371+", "+4+", "-NON-",
       "-01/01/2011 090905-", "-27/02/2011-"
     )
-  expect_equivalent(object = information_data_chunk(ft)$txt, expected)
+  expect_equal(object = information_data_chunk(ft)$txt, expected, ignore_attr = TRUE)
 })
 
 

--- a/tests/testthat/test-df_printer.R
+++ b/tests/testthat/test-df_printer.R
@@ -1,5 +1,3 @@
-context("df_printer and utilities")
-
 test_that("use_model_printer and use_df_printer works", {
   rmd_file <- tempfile(fileext = ".Rmd")
   file.copy("rmd/use-printer.Rmd", rmd_file)

--- a/tests/testthat/test-dimensions.R
+++ b/tests/testthat/test-dimensions.R
@@ -1,5 +1,3 @@
-context("check widths and heights")
-
 test_that("dimensions are valid", {
   dummy_df <- data.frame(my_col = rep(letters[1:3], each = 2), stringsAsFactors = FALSE)
   ft <- flextable(dummy_df)

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -1,6 +1,3 @@
-context("check errors")
-
-
 test_that("rows selections", {
   dummy_df <- data.frame(
     my_col = rep(letters[1:3], each = 2),

--- a/tests/testthat/test-footers.R
+++ b/tests/testthat/test-footers.R
@@ -1,5 +1,3 @@
-context("check footers")
-
 test_that("add_footer", {
   data_ref <- structure(
     list(

--- a/tests/testthat/test-footnote.R
+++ b/tests/testthat/test-footnote.R
@@ -1,5 +1,3 @@
-context("check footnotes")
-
 ft <- flextable(iris[1:5, ])
 ft <- footnote(
   x = ft, i = 1:3, j = 1:3,

--- a/tests/testthat/test-gen_grob.R
+++ b/tests/testthat/test-gen_grob.R
@@ -1,5 +1,3 @@
-context("check grid grob")
-
 gdtools::register_liberationsans()
 
 init_flextable_defaults()

--- a/tests/testthat/test-headers.R
+++ b/tests/testthat/test-headers.R
@@ -1,5 +1,3 @@
-context("check headers")
-
 test_that("set_header_labels", {
   col_keys <- c(
     "Species",

--- a/tests/testthat/test-images.R
+++ b/tests/testthat/test-images.R
@@ -1,5 +1,3 @@
-context("check images")
-
 data <- iris[c(1:3, 51:53, 101:104), ]
 col_keys <- c("Species", "sep_1", "Sepal.Length", "Sepal.Width", "sep_2", "Petal.Length", "Petal.Width")
 img.file <- file.path(R.home("doc"), "html", "logo.jpg")
@@ -107,16 +105,16 @@ test_that("multiple images", {
   }
 
   zz <- gen_grob(ft)
-  expect_is(zz$children$cell_1_1$children$contents$ftgrobs[[1]], "rastergrob")
-  expect_is(zz$children$cell_2_1$children$contents$ftgrobs[[1]], "rastergrob")
-  expect_is(zz$children$cell_3_1$children$contents$ftgrobs[[1]], "rastergrob")
+  expect_s3_class(zz$children$cell_1_1$children$contents$ftgrobs[[1]], "rastergrob")
+  expect_s3_class(zz$children$cell_2_1$children$contents$ftgrobs[[1]], "rastergrob")
+  expect_s3_class(zz$children$cell_3_1$children$contents$ftgrobs[[1]], "rastergrob")
 
   ft <- flextable(df)
   ft <- colformat_image(ft, j = "plot", width = 300 / 72, height = 300 / 72)
   zz <- gen_grob(ft)
-  expect_is(zz$children$cell_1_1$children$contents$ftgrobs[[1]], "text")
-  expect_is(zz$children$cell_2_1$children$contents$ftgrobs[[1]], "rastergrob")
-  expect_is(zz$children$cell_3_1$children$contents$ftgrobs[[1]], "rastergrob")
+  expect_s3_class(zz$children$cell_1_1$children$contents$ftgrobs[[1]], "text")
+  expect_s3_class(zz$children$cell_2_1$children$contents$ftgrobs[[1]], "rastergrob")
+  expect_s3_class(zz$children$cell_3_1$children$contents$ftgrobs[[1]], "rastergrob")
 })
 
 test_that("minibar", {

--- a/tests/testthat/test-keep_next.R
+++ b/tests/testthat/test-keep_next.R
@@ -1,5 +1,3 @@
-context("check keep with next")
-
 init_flextable_defaults()
 
 iris_sum <- summarizor(iris, by = "Species")

--- a/tests/testthat/test-latex.R
+++ b/tests/testthat/test-latex.R
@@ -1,5 +1,3 @@
-context("latex table structure")
-
 test_that("white spaces are protected", {
   ft <- flextable(data.frame(x = ""))
   ft <- delete_part(ft, part = "header")

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -1,5 +1,3 @@
-context("check hyperlink")
-
 data <- data.frame(
   code = c("X01", "X02"),
   name = c("X Number 1", "X Number 2"),
@@ -24,7 +22,7 @@ test_that("URL are preserved in docx", {
   rid <- xml_attr(xml_find_all(body, "//w:hyperlink"), "id")
   rels <- doc$doc_obj$rel_df()
   urls <- rels[rels$id %in% rid, "target"]
-  expect_equivalent(urls, sprintf(url_base, data$code))
+  expect_equal(urls, sprintf(url_base, data$code), ignore_attr = TRUE)
 })
 
 test_that("URL are preserved in pptx", {
@@ -35,7 +33,7 @@ test_that("URL are preserved in pptx", {
   rid <- xml_attr(xml_find_all(xml_slide, "//a:hlinkClick"), "id")
   rels <- doc$slide$get_slide(1)$rel_df()
   urls <- rels[rels$id %in% rid, "target"]
-  expect_equivalent(urls, sprintf(url_base, data$code))
+  expect_equal(urls, sprintf(url_base, data$code), ignore_attr = TRUE)
 })
 
 test_that("URL are preserved in html", {
@@ -46,5 +44,5 @@ test_that("URL are preserved in html", {
   str_ <- gsub("</div></template(.*)", "", str_)
   doc <- read_html(str_)
   urls <- xml_attr(xml_find_all(doc, "//a"), "href")
-  expect_equivalent(urls, sprintf(url_base, data$code))
+  expect_equal(urls, sprintf(url_base, data$code), ignore_attr = TRUE)
 })

--- a/tests/testthat/test-md-captions.R
+++ b/tests/testthat/test-md-captions.R
@@ -1,5 +1,3 @@
-context("check markdown captions")
-
 init_flextable_defaults()
 skip_if_not_local_testing(check_html = TRUE)
 snap_folder_test_file <- "md-captions"

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -1,10 +1,8 @@
-context("check merge operations")
-
 test_that("identical values within columns are merged", {
   dummy_df <- data.frame(values = rep(letters[1:3], each = 2), stringsAsFactors = FALSE)
   ft <- flextable(dummy_df)
   ft <- merge_v(x = ft, j = "values")
-  expect_equivalent(ft$body$spans$columns[, 1], rep(c(2, 0), 3))
+  expect_equal(ft$body$spans$columns[, 1], rep(c(2, 0), 3), ignore_attr = TRUE)
 })
 
 test_that("identical values within rows are merged", {
@@ -16,7 +14,7 @@ test_that("identical values within rows are merged", {
   ft <- flextable(dummy_df)
   ft <- merge_h(x = ft)
   ref <- matrix(c(rep(2, 26), rep(0, 26)), ncol = 2)
-  expect_equivalent(ft$body$spans$rows, ref)
+  expect_equal(ft$body$spans$rows, ref, ignore_attr = TRUE)
 })
 
 
@@ -29,9 +27,9 @@ test_that("span at", {
   ft <- flextable(dummy_df)
   ft <- merge_at(x = ft, i = 1:4, j = 1:2)
   ref <- matrix(c(rep(2, 4), rep(1, 22), rep(0, 4), rep(1, 22)), ncol = 2)
-  expect_equivalent(ft$body$spans$rows, ref)
+  expect_equal(ft$body$spans$rows, ref, ignore_attr = TRUE)
   ref <- matrix(c(4, rep(0, 3), rep(1, 22), 4, rep(0, 3), rep(1, 22)), ncol = 2)
-  expect_equivalent(ft$body$spans$columns, ref)
+  expect_equal(ft$body$spans$columns, ref, ignore_attr = TRUE)
 })
 
 

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,5 +1,3 @@
-context("check various minor things")
-
 ft <- flextable(iris)
 
 test_that("print as log", {

--- a/tests/testthat/test-new-rows.R
+++ b/tests/testthat/test-new-rows.R
@@ -1,5 +1,3 @@
-context("check dim and new rows")
-
 test_that("nrow_part or ncol_keys checks", {
   expect_error(nrow_part(12))
   expect_error(ncol_keys(12))
@@ -121,9 +119,10 @@ test_that("add part rows", {
       5, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0)
   )
   expect_true(all(spans$colspan %in% 1))
-  expect_equivalent(
+  expect_equal(
     colSums(is.na(ft_1$header$dataset)),
-    rep(0L, ncol(mtcars))
+    rep(0L, ncol(mtcars)),
+    ignore_attr = TRUE
   )
 
   new_body_sel <- x[x$.part %in% "body" &
@@ -143,9 +142,10 @@ test_that("add part rows", {
     c(5, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0)
   )
   expect_true(all(spans$colspan %in% 1))
-  expect_equivalent(
+  expect_equal(
     colSums(is.na(ft_1$body$dataset)),
-    rep(1L, ncol(mtcars))
+    rep(1L, ncol(mtcars)),
+    ignore_attr = TRUE
   )
 
   new_footer_sel <- x[x$.part %in% "footer" &
@@ -162,9 +162,10 @@ test_that("add part rows", {
     c(3, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0)
   )
   expect_true(all(spans$colspan %in% 1))
-  expect_equivalent(
+  expect_equal(
     colSums(is.na(ft_1$footer$dataset)),
-    rep(0L, ncol(mtcars))
+    rep(0L, ncol(mtcars)),
+    ignore_attr = TRUE
   )
 
 })

--- a/tests/testthat/test-padding.R
+++ b/tests/testthat/test-padding.R
@@ -1,5 +1,3 @@
-context("check paddings")
-
 test_that("padding overwrite all paddings", {
   ft <- flextable(data.frame(a = c("", ""), stringsAsFactors = FALSE))
   ft <- padding(ft, padding = 5)

--- a/tests/testthat/test-pptx-tables.R
+++ b/tests/testthat/test-pptx-tables.R
@@ -1,5 +1,3 @@
-context("ppt table structure")
-
 test_that("row height is valid", {
   ft <- flextable(head(iris))
   pptx_file <- "test.pptx"

--- a/tests/testthat/test-proc-freq.R
+++ b/tests/testthat/test-proc-freq.R
@@ -1,5 +1,3 @@
-context("check proc_freq")
-
 p <- structure(list(
   lengths = c(9894L, 104L, 1L, 1L),
   values = c("No", "Yes", NA, NA)
@@ -51,7 +49,7 @@ test_that("proc_freq executes without errors", {
     stringsAsFactors = FALSE
   )
   ft <- proc_freq(dummy_df, "values", "groups")
-  expect_equivalent(class(ft), "flextable")
+  expect_equal(class(ft), "flextable", ignore_attr = TRUE)
 })
 
 test_that("proc_freq content", {

--- a/tests/testthat/test-rotations.R
+++ b/tests/testthat/test-rotations.R
@@ -1,5 +1,3 @@
-context("check rotations")
-
 dat <- data.frame(
   a = c("left-top", "left-middle", "left-bottom"),
   b = c("center-top", "center-middle", "center-bottom"),

--- a/tests/testthat/test-styles.R
+++ b/tests/testthat/test-styles.R
@@ -82,3 +82,63 @@ test_that("borders with office docs are sanitized", {
   expect_equal(xml_attr(top_nodes, "w"), c("0", "0", "0", "12700"))
   expect_equal(xml_attr(bot_nodes, "w"), c("0", "12700", "0", "12700"))
 })
+
+test_that("align() accepts default align argument when columns is not a multiple of 4", {
+  ft <- flextable(head(mtcars, n = 2)[, 1:6])
+  ft1 <- align(ft, part = "all")
+  expect_snapshot_value(ft1$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft1$body$styles$pars$text.align$data, style = "deparse")
+})
+
+test_that("align() accepts combinations of align arguments.", {
+  ft <- flextable(head(mtcars, n = 2)[, 1:6])
+
+  # All columns right-aligned
+  ft2 <- align(ft, align = "right", part = "all")
+  expect_snapshot_value(ft2$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft2$body$styles$pars$text.align$data, style = "deparse")
+
+  # Custom alignment for each column
+  ft3 <- align(ft, align = c("left", "right", "left", "center", "center", "right"), part = "all")
+  expect_snapshot_value(ft3$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft3$body$styles$pars$text.align$data, style = "deparse")
+
+  # Custom alignment for only columns 3 and 5 in body only
+  ft4 <- align(ft, j = c(3, 5), align = c("center", "left"), part = "body")
+  expect_snapshot_value(ft4$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft4$body$styles$pars$text.align$data, style = "deparse")
+
+  # Custom alignment for only columns 3 and 5 in body only (using default body arg)
+  ft4b <- align(ft, j = c(3, 5), align = c("center", "left"))
+  expect_snapshot_value(ft4b$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft4b$body$styles$pars$text.align$data, style = "deparse")
+
+  # Center alignment for only columns 3 and 5
+  ft5 <- align(ft, j = c(3, 5), align = "center", part = "all")
+  expect_snapshot_value(ft5$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft5$body$styles$pars$text.align$data, style = "deparse")
+
+  # Alternate left and center alignment across columns 1-4 for header only
+  ft6 <- align(ft, j = 1:4, align = c("left", "center"), part = "header")
+  expect_snapshot_value(ft6$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft6$body$styles$pars$text.align$data, style = "deparse")
+
+  # Allow shorthand codes for alignment arguments.
+  ft7 <- align(ft, align = c("l", "r", "l", "c", "j", "r"), part = "all")
+  expect_snapshot_value(ft7$header$styles$pars$text.align$data, style = "deparse")
+  expect_snapshot_value(ft7$body$styles$pars$text.align$data, style = "deparse")
+})
+
+test_that("align() will error if invalid align and part arguments are supplied", {
+  ft <- flextable(head(mtcars, n = 2)[, 1:6])
+
+  # Invalid "part" argument
+  expect_error(align(ft, align = c("left", "center", "right"), part = "everything"))
+
+  # Invalid "align" argument
+  expect_error(align(ft, align = "top"))
+
+  # Invalid "align" argument mixed in with valid arguments throws warning
+  expect_warning(ft8 <- align(ft, align = c("top", "left")), "Invalid `align` argument")
+  expect_snapshot_value(ft8$body$styles$pars$text.align$data, style = "deparse")
+})

--- a/tests/testthat/test-styles.R
+++ b/tests/testthat/test-styles.R
@@ -1,5 +1,3 @@
-context("check formatting")
-
 test_that("shortcut functions", {
   ft <- flextable(head(mtcars, n = 2))
 

--- a/tests/testthat/test-text.R
+++ b/tests/testthat/test-text.R
@@ -1,5 +1,3 @@
-context("check cells text")
-
 ft1 <- flextable(data.frame(a = "1 < 3", stringsAsFactors = FALSE))
 
 get_xml_doc <- function(tab, main_folder = "docx_folder") {


### PR DESCRIPTION
I encountered an issue with the `align()` method when not setting an `align` argument and relying on the default value for the `align` argument. Usage from the `align()` docs:

```r
align(
  x,
  i = NULL,
  j = NULL,
  align = c("left", "center", "right", "justify"),
  part = "body"
)
```

However, a few lines later, the `match.arg` applied to `align` has `several.ok = TRUE`, which means all four values are accepted as the `align` argument.

This becomes a problem when the number of columns is not a multiple of 4 as the align argument tries to recycle itself across columns. Newer versions of R will error when recycling over a non-multiple value. The example in the documentation didn't flag this because it is an example dataset with 4 columns.

A small example to highlight the issue is:
``` r
library(flextable)

# 4 columns is fine
ft4 <- flextable(head(mtcars)[, 2:5])
ft4 <- align(ft4, part = "all")

# 8 columns doesn't error, but is messy because
# length(align_value) != length(j)
# so we don't `rep` the `align_value` by length(i)
ft8 <- flextable(head(mtcars)[, 2:9])
ft8 <- align(ft8, part = "all")

# 5 columns is not okay
ft5 <- flextable(head(mtcars[, 2:6]))
ft5 <- align(ft5, part = "all")
#> Error in x[[property]]$data[i, j] <- value: number of items to replace is not a multiple of replacement length
```

<sup>Created on 2024-04-11 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

These changes to `align()` attempt to patch this and reinforce the testing of the `align()` method. For the testing, I've employed test snapshots to confirm the relevant styling does filter down correctly into the table. However this requires a move to testthat version 3. The overhead of transitioning code to testthat 3 makes this PR cluttered, so you may find it easier to review one commit at a time. The three commits are

1. Changes needed to move to testthat version 3
2. Fix and tests associated with patching `align()`
3. Running the DESCRIPTION file through `usethis::use_tidy_description()` (not required, but an easy win)

More details about the changes made, reasons why, and consequences are in the NEWS.md file.