### PR TITLE
TMP FIX: use a double in internal function is_in_quarto()

### DIFF
--- a/R/printers.R
+++ b/R/printers.R
@@ -1117,7 +1117,7 @@ is_in_bookdown <- function() {
     isTRUE(!is_rdocx_document)
 }
 is_in_quarto <- function() {
-  isTRUE(knitr::opts_knit$get("quarto.version") > numeric_version("0"))
+  isTRUE(knitr::opts_knit$get("quarto.version") > 0)
 }
 is_in_pkgdown <- function() {
   identical(Sys.getenv("IN_PKGDOWN"), "true") &&


### PR DESCRIPTION
I think something has changed in knitr or R4.4.0 but  https://github.com/davidgohel/flextable/blob/8e21aaa98515e2feca5ea8b0cfab85b9d4a95aa3/R/printers.R#L1120C49-L1120C71 is broken with current CRAN packages and R4.4.0.

I think this fixes the issue but I've not dug further so treat accordingly.