### PR TITLE
fix: correct conversion from `in` to `mm` in `convmeters` function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -118,7 +118,7 @@ convmeters <- function(unit, x) {
   if (identical("cm", unit)) {
     x <- x * 2.54
   } else if (identical("mm", unit)) {
-    x <- x * 254
+    x <- x * 25.4
   }
   x
 }


### PR DESCRIPTION
Hi @davidgohel !
Thank you for this and your other incredibly useful packages!

This PR fixes the incorrect conversion factor from `in` to `mm` in the `convmeters` function.

Looking forward to your review and feedback. Thanks!