### PR TITLE
tests: avoid warnings for officer version 0.6.9

### DIFF
--- a/R/printers.R
+++ b/R/printers.R
@@ -809,7 +809,7 @@ save_as_pptx <- function(..., values = NULL, path) {
   show_names <- !is.null(titles)
   z <- read_pptx()
   for (i in seq_along(values)) {
-    z <- add_slide(z)
+    z <- add_slide(z, "Title and Content")
     if (show_names) {
       z <- ph_with(z, titles[i], location = ph_location_type(type = "title"))
     }


### PR DESCRIPTION
Hi @davidgohel ,

this is a mini commit to avoid warnings during tests. It just adds the layout name to `add_slide()` in `save_as_pptx()`. A missing layout would result in a warning in the future due to changes introduced in {officer} commit [ee4ca7](https://github.com/davidgohel/officer/commit/ee4ca76cc9f40ce8969c6d7a02105f49b7d11399)