### PR TITLE
fix: map_visible_columns outputting non-unique col_keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: flextable
 Title: Functions for Tabular Reporting
-Version: 0.9.11.018
+Version: 0.9.11.019
 Authors@R: c(
     person("David", "Gohel", , "david.gohel@ardata.fr", role = c("aut", "cre")),
     person("ArData", role = "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,9 @@ PDF/LaTeX output when rows have different heights (#639). Content is
 placed in the first (top), middle (center), or last (bottom) row of the
 merged range; `\multirow` is no longer used as it miscalculates offsets
 with unequal row heights.
+- using `by` of `summarizor()` referring to two columns, one of which has
+only one unique value no longer causes and error when passed on to 
+`as_flextable()`.
 
 # flextable 0.9.10
 

--- a/R/as_flextable_tabulator.R
+++ b/R/as_flextable_tabulator.R
@@ -757,6 +757,10 @@ map_visible_columns <- function(dat, columns, rows, value_names = character(0),
   sel_columns <- columns[seq_len(length(columns) - 2)]
 
   for (j in rev(seq_along(sel_columns))) {
+    # Check if any group has more than 1 row (only then do we need separators)
+    group_sizes <- table(rleid(ldims[[j]]))
+    if (all(group_sizes <= 1)) next
+
     ldims <- split(ldims, rleid(ldims[[j]]))
     ldims <- lapply(ldims, function(x, j) {
       x[nrow(x), j] <- "dummy"


### PR DESCRIPTION
This PR fixes an issue inside the as_flextable method of `tabulator` objects.

When passing a `data.frame` to `summarizor()` using 2 `by` columns, if one of the columns only had one unique value then there was an error caused due to non-unique `col_keys` being passed onto `flextable`. The fix checks if any group has more than 1 row, in which case separators are needed for nested columns otherwise they are not.

Here is a reprex that previously threw an error, but now works:
```
dat <- penguins
dat$species <- "Penguin"

by <- c("island", "species")

obj <- summarizor(
  x = dat,
  by = by
)

# error here
ft <- as_flextable(
  x = obj,
  sep_w = 0,
  spread_first_col = TRUE
)

```